### PR TITLE
feat: refactor actions from classes to functions that return objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
       }
     },
     "collectCoverageFrom": [
-      "src/*.{js,ts}"
+      "src/*.{ts,tsx}"
     ]
   },
   "prettier": {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,56 +1,96 @@
-import { RNSOpts, RNSLevel } from './util'
+import { NotifyOpts, NotifyLevel } from './util'
 import { Action } from 'redux'
 
 /**
- * Show a notification with the given options and level.
+ * REALLY lame unique id generation for notifications that don't provide
+ * a value for "uid"
+ * @internal
  */
-export class RNSShowAction implements Action {
-  private static _uidCount = 0
-  static typeId: '@SHOW_NOTIFICATION' = '@SHOW_NOTIFICATION'
-  type = RNSShowAction.typeId
-  constructor(public payload: Partial<RNSOpts>, level: RNSLevel) {
-    this.payload.level = level
-    if (!this.payload.uid) {
-      this.payload.uid = `notify_${++RNSShowAction._uidCount}`
+let uidCounter = 0
+
+/** String literal type used for show notification action "type" */
+export const NotifyShowType = '@showNotification'
+/** Redux action object for showing a notification */
+export interface INotifyShow extends Action {
+  readonly type: '@showNotification'
+  readonly payload: Partial<NotifyOpts>
+}
+/** Show a notification with the given options and level */
+export function NotifyShow(payload: Partial<NotifyOpts>, level: NotifyLevel): INotifyShow {
+  return {
+    type: NotifyShowType,
+    payload: {
+      ...payload,
+      // The level is set by the caller
+      level,
+      // Add a UID if none is present
+      uid: payload.uid || `notify_${++uidCounter}`
     }
   }
 }
+/** String literal type constant for hide notification action "type" member */
+export const NotifyHideType = '@hideNotification'
+/** Redux action object shape for hiding a notification */
+export interface INotifyHide extends Action {
+  readonly payload: number | string
+  readonly type: '@hideNotification'
+}
+/**
+ * Generate a redux {@see Action} object that hides any notification with
+ * the given id when dispatched
+ */
+export function NotifyHide(uid: number | string): INotifyHide {
+  return {
+    type: NotifyHideType,
+    payload: uid
+  }
+}
+/** String literal type constant for clear notifications action "type" member */
+export const NotifyClearType = '@clearNotifications'
+/** Redux action object shape for clearing all notifications */
+export interface INotifyClear extends Action {
+  readonly type: '@clearNotifications'
+}
+/**
+ * Generate a redux {@see Action} object that clear all notifications when dispatched
+ */
+export function NotifyClear(): INotifyClear {
+  return {
+    type: NotifyClearType
+  }
+}
 
-export class RNSHideAction implements Action {
-  static typeId: '@HIDE_NOTIFICATION' = '@HIDE_NOTIFICATION'
-  type = RNSHideAction.typeId
-  constructor(public payload?: string | number) {}
+/**
+ * Generate a redux {@see Action} object shows a notification with the "success"
+ * styles applied when dispatched
+ */
+export function NotifySuccess(payload: Partial<NotifyOpts>) {
+  return NotifyShow(payload, 'success')
 }
-
-export class RNSClearAction implements Action {
-  static typeId: '@CLEAR_ALL_NOTIFICIATIONS' = '@CLEAR_ALL_NOTIFICIATIONS'
-  type = RNSClearAction.typeId
-  payload = null
+/**
+ * Generate a redux {@see Action} object shows a notification with the "error"
+ * styles applied when dispatched
+ */
+export function NotifyError(payload: Partial<NotifyOpts>) {
+  return NotifyShow(payload, 'error')
 }
-
-export class RNSSuccessAction extends RNSShowAction {
-  constructor(public payload: Partial<RNSOpts>) {
-    super(payload, 'success')
-  }
+/**
+ * Generate a redux {@see Action} object shows a notification with the "warning"
+ * styles applied when dispatched
+ */
+export function NotifyWarning(payload: Partial<NotifyOpts>) {
+  return NotifyShow(payload, 'warning')
 }
-export class RNSErrorAction extends RNSShowAction {
-  constructor(public payload: Partial<RNSOpts>) {
-    super(payload, 'error')
-  }
-}
-export class RNSWarningAction extends RNSShowAction {
-  constructor(public payload: Partial<RNSOpts>) {
-    super(payload, 'warning')
-  }
-}
-export class RNSInfoAction extends RNSShowAction {
-  constructor(public payload: Partial<RNSOpts>) {
-    super(payload, 'info')
-  }
+/**
+ * Generate a redux {@see Action} object shows a notification with the "info"
+ * styles applied when dispatched
+ */
+export function NotifyInfo(payload: Partial<NotifyOpts>) {
+  return NotifyShow(payload, 'info')
 }
 
 /**
  * Tagged union types (note the convenience functions that set levels are not
- * here because they share an action type with RNSShowAction)
+ * here because they share an action type with IShowNotification)
  */
-export type RNSActionTypes = RNSShowAction | RNSHideAction | RNSClearAction
+export type NotifyActionTypes = INotifyShow | INotifyHide | INotifyClear

--- a/src/notifications.tsx
+++ b/src/notifications.tsx
@@ -1,21 +1,21 @@
 import React from 'react'
 import ReactNotificationSystem, { System } from 'react-notification-system'
 import { Dispatch, Action } from 'redux'
-import { RNSOpts } from './util'
-import { RNSHideAction, RNSActionTypes } from './actions'
+import { NotifyOpts } from './util'
+import { NotifyHide, NotifyActionTypes } from './actions'
 
-export interface RNSComponentProps<T = any> {
-  notifications: RNSOpts[]
+export interface NotifyComponentProps<T = any> {
+  notifications: NotifyOpts[]
   dispatch?: Dispatch<Action<T>>
 }
 
-export class RNSComponent<T = {}> extends React.Component<RNSComponentProps<T>> {
+export class NotifyComponent<T = {}> extends React.Component<NotifyComponentProps<T>> {
   notify: React.RefObject<any> = React.createRef()
   system(): System {
     return this.notify.current
   }
 
-  getDispatch(): Dispatch<RNSActionTypes> {
+  getDispatch(): Dispatch<NotifyActionTypes> {
     const result = this.context.store ? this.context.store.disaptch : this.props.dispatch
     if (!result) {
       throw new Error(
@@ -25,10 +25,10 @@ export class RNSComponent<T = {}> extends React.Component<RNSComponentProps<T>> 
     return result
   }
 
-  componentWillReceiveProps<T>(nextProps: Readonly<RNSComponentProps<T>>) {
+  componentWillReceiveProps<T>(nextProps: Readonly<NotifyComponentProps<T>>) {
     const { notifications } = nextProps
     const notificationIds = notifications.map(notification => notification.uid)
-    const systemNotifications = this.system().state.notifications || []
+    const systemNotifications = this.system().state.notifications
 
     if (notifications.length > 0) {
       // Get all active notifications from react-notification-system
@@ -45,7 +45,7 @@ export class RNSComponent<T = {}> extends React.Component<RNSComponentProps<T>> 
           onRemove: () => {
             notification.onRemove && notification.onRemove()
             const dispatch = this.getDispatch()
-            dispatch(new RNSHideAction(notification.uid))
+            dispatch(NotifyHide(notification.uid))
           }
         } as any)
       })
@@ -56,7 +56,7 @@ export class RNSComponent<T = {}> extends React.Component<RNSComponentProps<T>> 
     }
   }
 
-  shouldComponentUpdate<T>(nextProps: RNSComponentProps<T>) {
+  shouldComponentUpdate<T>(nextProps: NotifyComponentProps<T>) {
     return this.props !== nextProps
   }
 

--- a/src/notifications.tsx
+++ b/src/notifications.tsx
@@ -34,7 +34,7 @@ export class NotifyComponent<T = {}> extends React.Component<NotifyComponentProp
       // Get all active notifications from react-notification-system
       /// and remove all where uid is not found in the reducer
       systemNotifications.forEach(notification => {
-        if (notificationIds.indexOf(notification.uid) < 0) {
+        if (notification.uid && notificationIds.indexOf(notification.uid) === -1) {
           this.system().removeNotification(notification.uid as string)
         }
       })

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -1,23 +1,20 @@
-import { RNSShowAction, RNSHideAction, RNSClearAction, RNSActionTypes } from './actions'
-import { exhaustiveCheck, RNSOpts } from './util'
+import { NotifyShowType, NotifyHideType, NotifyClearType, NotifyActionTypes } from './actions'
+import { exhaustiveCheck, NotifyOpts } from './util'
 
-export type NotificationsStoreState = RNSOpts[]
+export type NotifyState = NotifyOpts[]
 
-export function RNSReducer(
-  state: NotificationsStoreState = [],
-  action?: RNSActionTypes
-): NotificationsStoreState {
+export function NotifyReducer(state: NotifyState = [], action?: NotifyActionTypes): NotifyState {
   if (action) {
     switch (action.type) {
-      case RNSShowAction.typeId: {
-        const ops = action.payload as RNSOpts
+      case NotifyShowType: {
+        const ops = action.payload as NotifyOpts
         return [...state, { ...ops }]
       }
-      case RNSHideAction.typeId: {
+      case NotifyHideType: {
         const { payload } = action
         return state.filter(notification => notification.uid !== payload)
       }
-      case RNSClearAction.typeId: {
+      case NotifyClearType: {
         return []
       }
       /* istanbul ignore next */

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,12 +1,13 @@
-export type RNSLevel = 'success' | 'warning' | 'error' | 'info'
+export type NotifyLevel = 'success' | 'warning' | 'error' | 'info'
 
-export interface RNSOpts {
-  uid?: string | number
-  level?: RNSLevel
-  title?: string
+export interface NotifyOpts {
+  uid: string | number
+  level?: NotifyLevel
+  title: string
   message: string
   position: string
   autoDismiss: number
+  dismissible?: boolean
   action: {
     label: string
     callback: () => void

--- a/test/actions.spec.ts
+++ b/test/actions.spec.ts
@@ -1,23 +1,23 @@
-import { RNSSuccessAction, RNSErrorAction, RNSInfoAction, RNSWarningAction } from '../src'
+import { NotifySuccess, NotifyError, NotifyInfo, NotifyWarning } from '../src'
 
 describe('redux actions', () => {
   it('should set the correct notification level when using convenience class actions', () => {
-    expect(new RNSSuccessAction({}).payload.level).toEqual('success')
-    expect(new RNSWarningAction({}).payload.level).toEqual('warning')
-    expect(new RNSInfoAction({}).payload.level).toEqual('info')
-    expect(new RNSErrorAction({}).payload.level).toEqual('error')
+    expect(NotifySuccess({}).payload.level).toEqual('success')
+    expect(NotifyWarning({}).payload.level).toEqual('warning')
+    expect(NotifyInfo({}).payload.level).toEqual('info')
+    expect(NotifyError({}).payload.level).toEqual('error')
   })
 
   it('accepts custom opts', () => {
-    expect(new RNSSuccessAction({ data: { custom: true } }).payload.data.custom).toBe(true)
+    expect(NotifySuccess({ data: { custom: true } }).payload.data.custom).toBe(true)
   })
 
   it('generates random uid when not provided', () => {
-    expect(new RNSSuccessAction({}).payload.uid).toBeDefined()
-    expect(new RNSSuccessAction({}).payload.uid).not.toBeFalsy()
+    expect(NotifySuccess({}).payload.uid).toBeDefined()
+    expect(NotifySuccess({}).payload.uid).not.toBeFalsy()
   })
 
   it('sets the custom uid when provided', () => {
-    expect(new RNSSuccessAction({ uid: 1 }).payload.uid).toEqual(1)
+    expect(NotifySuccess({ uid: 1 }).payload.uid).toEqual(1)
   })
 })

--- a/test/reducer.spec.ts
+++ b/test/reducer.spec.ts
@@ -1,13 +1,13 @@
-import { RNSReducer, RNSHideAction, RNSSuccessAction, RNSClearAction } from './../src'
+import { NotifyReducer, NotifyHide, NotifySuccess, NotifyClear } from './../src'
 
 describe('reducer', () => {
   it('initializes state with an array', () => {
-    expect(RNSReducer()).toEqual([])
+    expect(NotifyReducer()).toEqual([])
   })
 
   it('stores the notification to state', () => {
-    const action = new RNSSuccessAction({})
-    const state = RNSReducer([], action)
+    const action = NotifySuccess({})
+    const state = NotifyReducer([], action)
 
     expect(state.length).toBe(1)
   })
@@ -15,17 +15,17 @@ describe('reducer', () => {
   it('stores and removes notification', () => {
     const uid = 1
 
-    const state = RNSReducer([], new RNSSuccessAction({ uid }))
+    const state = NotifyReducer([], NotifySuccess({ uid }))
     expect(state.length).toBe(1)
 
-    const newState = RNSReducer(state, new RNSHideAction(uid))
+    const newState = NotifyReducer(state, NotifyHide(uid))
     expect(newState.length).toBe(0)
   })
 
   it('removes all notifications', () => {
-    const state = RNSReducer([], new RNSSuccessAction({ uid: 1 }))
-    const newState = RNSReducer(state, new RNSSuccessAction({ uid: 2 }))
-    const emptyState = RNSReducer(newState, new RNSClearAction())
+    const state = NotifyReducer([], NotifySuccess({ uid: 1 }))
+    const newState = NotifyReducer(state, NotifySuccess({ uid: 2 }))
+    const emptyState = NotifyReducer(newState, NotifyClear())
     expect(newState.length).toBe(2)
     expect(emptyState.length).toBe(0)
   })


### PR DESCRIPTION
 - react's version of redux throws an error if it's given a class instance with a type field. I thought the classes were a really tight way of defining actions that can be discriminated. :sob:
 - surprisingly, this is more verbose than using classes, and it also has the disadvantage that `exhaustiveCheck` errors don't lead you to the EXACT symbol you need (but to the nearby type constant.)
 - add a few tests to keep the coverage up after fixing jest to include coverage data for notifications.tsx :sweat_smile:
 - simplify the API to use a "Notify{Name}" convention. NotifyClear() to clear, NotifyError() to show an error, etc.
 - add documentation to all the reducer actions

BREAKING CHANGE: public API names refactored

The format used to include an RNS prefix and an Action suffix, i.e. "RNS{NAME}Action". Now it only includes a prefix: "Notify{Name}" Here are a few examples
 - RNSShowAction -> NotifyShow
 - RNSHideAction -> NotifyHide
 - RNSErrorAction -> NotifyError
 - RNSOpts -> NotifyOpts
 - RNSComponent -> NotifyComponent