### PR TITLE
Store effects

### DIFF
--- a/src/model/api.ts
+++ b/src/model/api.ts
@@ -1,5 +1,4 @@
 import { NotifyOpts, NotifyState, NotifyDispatch } from '../types'
-import { CONSTANTS } from '../constants'
 import { NotifyHide, NotifyShow, NotifyEdit, NotifyClear, NotifyRemove } from './actions'
 import { invariant } from '../helpers'
 
@@ -17,10 +16,6 @@ export class NotifyAPI {
   }
 
   addNotification(notification: Partial<NotifyOpts>): NotifyOpts {
-    // TODO: This should be an effect... probably on the NotifyProvider
-    if (typeof notification.onAdd === 'function') {
-      notification.onAdd(notification as NotifyOpts)
-    }
     this.dispatch(NotifyShow(notification))
     return notification as NotifyOpts
   }
@@ -37,10 +32,6 @@ export class NotifyAPI {
     const notification = this.findNotification(uid)
     if (notification) {
       this.dispatch(NotifyRemove(uid))
-      // TODO: This effect should exist on notify provider like other comment
-      if (notification.onRemove) {
-        notification.onRemove(notification)
-      }
       return true
     }
     return false

--- a/test/components.spec.tsx
+++ b/test/components.spec.tsx
@@ -468,33 +468,4 @@ describe('NotifyPortal Component', () => {
   //   done()
   // })
 
-  it('should throw an error if no level is defined', () => {
-    const note = getNote()
-    delete note.level
-    expect(() => renderNotifications([note])).toThrow(/notification level is required/)
-  })
-
-  it('should throw an error if a invalid level is defined', () => {
-    const note = getNote({
-      uid: defaultId,
-      level: 'invalid' as any
-    })
-    expect(() => renderNotifications([note])).toThrow(/is not a valid level/)
-  })
-
-  it('should throw an error if a invalid position is defined', () => {
-    const note = getNote({
-      uid: defaultId,
-      position: 'invalid' as any
-    })
-    expect(() => renderNotifications([note])).toThrow(/is not a valid position/)
-  })
-
-  it('should throw an error if autoDismiss is not a number', () => {
-    const note = getNote({
-      uid: defaultId,
-      autoDismiss: 'invalid' as any
-    })
-    expect(() => renderNotifications([note])).toThrow(/\'autoDismiss\' must be a number./)
-  })
 })

--- a/test/reducer.spec.ts
+++ b/test/reducer.spec.ts
@@ -38,6 +38,34 @@ describe('reducer', () => {
       expect(state.notifications[0].message).toBe('bar')
       expect(newState.notifications[0].message).toBe('foo')
     })
+
+    it('should throw an error if no level is defined', () => {
+      const action = NotifySuccess({})
+      const state = getInitialNotifyState()
+      delete action.payload.level
+      expect(() => NotifyReducer(state, action)).toThrow(/notification level is required/)
+    })
+
+    it('should throw an error if a invalid level is defined', () => {
+      const action = NotifySuccess({})
+      const state = getInitialNotifyState()
+      action.payload.level = 'invalid' as any
+      expect(() => NotifyReducer(state, action)).toThrow(/is not a valid level/)
+    })
+
+    it('should throw an error if a invalid position is defined', () => {
+      const action = NotifySuccess({})
+      const state = getInitialNotifyState()
+      action.payload.position = 'invalid' as any
+      expect(() => NotifyReducer(state, action)).toThrow(/is not a valid position/)
+    })
+
+    it('should throw an error if autoDismiss is not a number', () => {
+      const action = NotifySuccess({})
+      const state = getInitialNotifyState()
+      action.payload.autoDismiss = 'invalid' as any
+      expect(() => NotifyReducer(state, action)).toThrow(/\'autoDismiss\' must be a number./)
+    })
   })
   describe('NotifyHide', () => {
     it('marks notifications as hidden but does not remove them', () => {

--- a/test/reducer.spec.ts
+++ b/test/reducer.spec.ts
@@ -64,7 +64,7 @@ describe('reducer', () => {
       const action = NotifySuccess({})
       const state = getInitialNotifyState()
       action.payload.autoDismiss = 'invalid' as any
-      expect(() => NotifyReducer(state, action)).toThrow(/\'autoDismiss\' must be a number./)
+      expect(() => NotifyReducer(state, action)).toThrow(/"autoDismiss" must be a number./)
     })
   })
   describe('NotifyHide', () => {


### PR DESCRIPTION
This fixes the plain Redux use-case where you dispatch a partial `NotifyOpts` object. Before it would bypass the default initializers for notifications, so no buttons would be present, etc.

This moves the impure parts of the `NotifyAPI` methods into React effects that fire when the redux state changes. 🎉 
