### PR TITLE
Classnames

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1864,6 +1864,12 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@types/classnames": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.7.tgz",
+      "integrity": "sha512-rzOhiQ55WzAiFgXRtitP/ZUT8iVNyllEpylJ5zHzR4vArUvMB39GTk+Zon/uAM0JxEFAWnwsxC2gH8s+tZ3Myg==",
+      "dev": true
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -3247,6 +3253,11 @@
           "dev": true
         }
       }
+    },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "clean-stack": {
       "version": "2.0.0",
@@ -4968,14 +4979,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4990,20 +4999,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5120,8 +5126,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5133,7 +5138,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5148,7 +5152,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5156,14 +5159,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5182,7 +5183,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5263,8 +5263,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5276,7 +5275,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5398,7 +5396,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@semantic-release/git": "^7.0.7",
     "@semantic-release/github": "^5.2.9",
     "@semantic-release/npm": "^5.1.3",
+    "@types/classnames": "^2.2.7",
     "@types/jest": "^23.3.2",
     "@types/jsdom": "^12.2.1",
     "@types/node": "^10.11.0",
@@ -143,11 +144,13 @@
     "typescript": "^3.0.3"
   },
   "dependencies": {
+    "classnames": "^2.2.6",
     "react": "^16.8.0-alpha || ^16.8",
     "react-dom": "^16.8.0-alpha || ^16.8",
     "redux": "^4.0.1"
   },
   "peerDependencies": {
+    "classnames": "^2.2.6",
     "react": "^16.8.0-alpha || ^16.8",
     "react-dom": "^16.8.0-alpha || ^16.8",
     "redux": "^4.0.1"

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -16,7 +16,7 @@ export default {
     { file: pkg.module, format: 'es', sourcemap: true }
   ],
   // Indicate here external modules you don't wanna include in your bundle (i.e.: 'lodash')
-  external: ['react', 'react-dom', 'redux', 'prop-types'],
+  external: ['react', 'react-dom', 'redux', 'prop-types', 'classnames'],
   watch: {
     include: 'src/**'
   },

--- a/src/components/container.tsx
+++ b/src/components/container.tsx
@@ -63,8 +63,9 @@ export class NotifyContainer extends React.Component<NotifyContainerProps> {
       )
     })
 
+    const containerName = CONSTANTS.testing.containerTestId(position)
     return (
-      <div data-testid={CONSTANTS.testing.containerTestId(position)} style={this._style}>
+      <div data-testid={containerName} className={containerName} style={this._style}>
         {notifications}
       </div>
     )

--- a/src/components/item.tsx
+++ b/src/components/item.tsx
@@ -5,6 +5,7 @@ import { NotifyOpts } from '../types'
 import { CONSTANTS } from '../constants'
 import { Timer, invariant } from '../helpers'
 import { NotifyAPI } from '../model/api'
+import classNames from 'classnames'
 
 export interface NotifyItemProps {
   id?: string
@@ -224,24 +225,19 @@ export class NotifyItem extends React.Component<NotifyItemProps, NotifyItemState
   }
 
   render() {
+    const { visible } = this.state
     let notification = this.props.notification
-    let className = `notification notification-${notification.level} notify-item`
+    const className = classNames('notify', 'notify-item', `notify-${notification.level}`, {
+      'notify-visible': visible,
+      'notify-hidden': visible === false,
+      'notify-not-dismissable': notification.dismissible === 'none'
+    })
     let notificationStyle = { ...this._styles.notification }
     let cssByPos = this._getCssPropertyByPosition()
     let dismiss = null
     let actionButton = null
     let title = null
     let message = null
-
-    if (this.state.visible) {
-      className += ' notification-visible'
-    } else if (this.state.visible === false) {
-      className += ' notification-hidden'
-    }
-
-    if (notification.dismissible === 'none') {
-      className += ' notification-not-dismissible'
-    }
 
     if (this.props.getStyles.overrideStyle) {
       if (!this.state.visible && !this.state.removed) {
@@ -267,7 +263,7 @@ export class NotifyItem extends React.Component<NotifyItemProps, NotifyItemState
 
     if (notification.title) {
       title = (
-        <h4 className="notification-title" style={this._styles.title}>
+        <h4 className="notify-title" style={this._styles.title}>
           {notification.title}
         </h4>
       )
@@ -277,14 +273,14 @@ export class NotifyItem extends React.Component<NotifyItemProps, NotifyItemState
       if (this.props.allowHTML) {
         message = (
           <div
-            className="notification-message"
+            className="notify-message"
             style={this._styles.messageWrapper}
             dangerouslySetInnerHTML={_allowHTML(notification.message)}
           />
         )
       } else {
         message = (
-          <div className="notification-message" style={this._styles.messageWrapper}>
+          <div className="notify-message" style={this._styles.messageWrapper}>
             {notification.message}
           </div>
         )
@@ -296,7 +292,7 @@ export class NotifyItem extends React.Component<NotifyItemProps, NotifyItemState
       notification.dismissible === true
     ) {
       dismiss = (
-        <span className="notification-dismiss" onClick={this._dismiss} style={this._styles.dismiss}>
+        <span className="notify-dismiss" onClick={this._dismiss} style={this._styles.dismiss}>
           &times;
         </span>
       )
@@ -304,9 +300,9 @@ export class NotifyItem extends React.Component<NotifyItemProps, NotifyItemState
 
     if (notification.action) {
       actionButton = (
-        <div className="notification-action-wrapper" style={this._styles.actionWrapper}>
+        <div className="notify-action-wrapper" style={this._styles.actionWrapper}>
           <button
-            className="notification-action-button"
+            className="notify-action-button"
             onClick={this._defaultAction}
             style={this._styles.action}
           >

--- a/src/components/item.tsx
+++ b/src/components/item.tsx
@@ -225,13 +225,19 @@ export class NotifyItem extends React.Component<NotifyItemProps, NotifyItemState
   }
 
   render() {
-    const { visible } = this.state
-    let notification = this.props.notification
-    const className = classNames('notify', 'notify-item', `notify-${notification.level}`, {
-      'notify-visible': visible,
-      'notify-hidden': visible === false,
-      'notify-not-dismissable': notification.dismissible === 'none'
-    })
+    const { visible, removed } = this.state
+    const { notification, getStyles: styles } = this.props
+    const className = classNames(
+      'notify',
+      'notify-item',
+      `notify-${notification.level}`,
+      CONSTANTS.testing.itemId(notification.uid),
+      {
+        'notify-visible': visible,
+        'notify-hidden': visible === false,
+        'notify-not-dismissable': notification.dismissible === 'none'
+      }
+    )
     let notificationStyle = { ...this._styles.notification }
     let cssByPos = this._getCssPropertyByPosition()
     let dismiss = null
@@ -239,24 +245,24 @@ export class NotifyItem extends React.Component<NotifyItemProps, NotifyItemState
     let title = null
     let message = null
 
-    if (this.props.getStyles.overrideStyle) {
-      if (!this.state.visible && !this.state.removed) {
+    if (styles.overrideStyle) {
+      if (!visible && !removed) {
         notificationStyle[cssByPos.property] = cssByPos.value
       }
 
-      if (this.state.visible && !this.state.removed) {
+      if (visible && !removed) {
         notificationStyle.height = this._height
         notificationStyle[cssByPos.property] = 0
       }
 
-      if (this.state.removed) {
+      if (removed) {
         notificationStyle.overlay = 'hidden'
         notificationStyle.height = 0
         notificationStyle.marginTop = 0
         notificationStyle.paddingTop = 0
         notificationStyle.paddingBottom = 0
       }
-      notificationStyle.opacity = this.state.visible
+      notificationStyle.opacity = visible
         ? this._styles.notification.isVisible.opacity
         : this._styles.notification.isHidden.opacity
     }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -45,3 +45,11 @@ export function invariant(expression: any, message: string) {
     throw new Error(`Invariant failed: ${message}`)
   }
 }
+
+// from: https://stackoverflow.com/questions/22266826/how-can-i-do-a-shallow-comparison-of-the-properties-of-two-objects-with-javascri
+export function shallowCompare(obj1: any, obj2: any): boolean {
+  return (
+    Object.keys(obj1).length === Object.keys(obj2).length &&
+    Object.keys(obj1).every((key: string) => obj2.hasOwnProperty(key) && obj1[key] === obj2[key])
+  )
+}

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -3,6 +3,7 @@ import { NotifyPortal, NotifyPortalProps } from './components/portal'
 import { NotifyDispatch, NotifyState, NotifyOpts } from './types'
 import { getInitialNotifyState, NotifyReducer } from './model/reducer'
 import { INotifyContext, NotifyContext } from './context'
+import { shallowCompare } from './helpers'
 
 export interface NotifyProviderProps extends Partial<NotifyPortalProps> {
   readonly state?: NotifyState
@@ -65,14 +66,6 @@ export function NotifyProvider(props: NotifyProviderProps) {
       </Fragment>
     </NotifyContext.Provider>
   )
-
-  // from: https://stackoverflow.com/questions/22266826/how-can-i-do-a-shallow-comparison-of-the-properties-of-two-objects-with-javascri
-  function shallowCompare(obj1: any, obj2: any) {
-    return (
-      Object.keys(obj1).length === Object.keys(obj2).length &&
-      Object.keys(obj1).every((key: string) => obj2.hasOwnProperty(key) && obj1[key] === obj2[key])
-    )
-  }
 }
 // TODO: Redux friendly wrapper that automatically pulls state/dispatch from ReduxContext?
 // probably need to support both the react-redux internal context and the facebook incubator

--- a/test/components.spec.tsx
+++ b/test/components.spec.tsx
@@ -277,7 +277,7 @@ describe('NotifyPortal Component', () => {
   xit('should set the notification class to visible after added', () => {
     const { root } = renderNotifications([getNote(defaultId)])
     let notification = root.getByTestId(CONSTANTS.testing.itemId(defaultId))
-    expect(notification.className).toMatch(/notification/)
+    expect(notification.className).toMatch(/notify/)
     jest.runTimersToTime(400)
     expect(notification.className).toMatch(/notify-visible/)
   })
@@ -324,7 +324,7 @@ describe('NotifyPortal Component', () => {
       toAdd.push(getNote())
     }
     const { root } = renderNotifications(toAdd)
-    let notifications = root.container.querySelectorAll('.notification')
+    let notifications = root.container.querySelectorAll('.notify')
     expect(notifications.length).toBe(10)
   })
 
@@ -332,38 +332,38 @@ describe('NotifyPortal Component', () => {
   //   notificationObj.uid = 500
   //   component.addNotification(notificationObj)
   //   component.addNotification(notificationObj)
-  //   let notification = scryRenderedDOMComponentsWithClass(instance, 'notification')
+  //   let notification = scryRenderedDOMComponentsWithClass(instance, 'notify')
   //   expect(notification.length).toBe(1)
   // })
 
   // it('should remove a notification using returned object', done => {
   //   let notificationCreated = component.addNotification(defaultNotification) as NotifyOpts
   //   expect(notificationCreated).not.toBe(false)
-  //   let notification = scryRenderedDOMComponentsWithClass(instance, 'notification')
+  //   let notification = scryRenderedDOMComponentsWithClass(instance, 'notify')
   //   expect(notification.length).toBe(1)
 
   //   component.removeNotification(notificationCreated)
   //   jest.runTimersToTime(1000)
-  //   let notificationRemoved = scryRenderedDOMComponentsWithClass(instance, 'notification')
+  //   let notificationRemoved = scryRenderedDOMComponentsWithClass(instance, 'notify')
   //   expect(notificationRemoved.length).toBe(0)
   //   done()
   // })
 
   // it('should remove a notification using uid', done => {
   //   let notificationCreated = component.addNotification(defaultNotification) as NotifyOpts
-  //   let notification = scryRenderedDOMComponentsWithClass(instance, 'notification')
+  //   let notification = scryRenderedDOMComponentsWithClass(instance, 'notify')
   //   expect(notification.length).toBe(1)
 
   //   component.removeNotification(notificationCreated.uid)
   //   jest.runTimersToTime(200)
-  //   let notificationRemoved = scryRenderedDOMComponentsWithClass(instance, 'notification')
+  //   let notificationRemoved = scryRenderedDOMComponentsWithClass(instance, 'notify')
   //   expect(notificationRemoved.length).toBe(0)
   //   done()
   // })
 
   // it('should edit an existing notification using returned object', done => {
   //   const notificationCreated = component.addNotification(defaultNotification) as NotifyOpts
-  //   const notification = scryRenderedDOMComponentsWithClass(instance, 'notification')
+  //   const notification = scryRenderedDOMComponentsWithClass(instance, 'notify')
   //   expect(notification.length).toBe(1)
 
   //   const newTitle = 'foo'
@@ -383,7 +383,7 @@ describe('NotifyPortal Component', () => {
 
   // it('should edit an existing notification using uid', done => {
   //   const notificationCreated = component.addNotification(defaultNotification) as NotifyOpts
-  //   const notification = scryRenderedDOMComponentsWithClass(instance, 'notification')
+  //   const notification = scryRenderedDOMComponentsWithClass(instance, 'notify')
   //   expect(notification.length).toBe(1)
 
   //   const newTitle = 'foo'
@@ -391,7 +391,7 @@ describe('NotifyPortal Component', () => {
 
   //   component.editNotification(notificationCreated.uid, { title: newTitle, message: newContent })
   //   jest.runTimersToTime(1000)
-  //   const notificationEdited = findRenderedDOMComponentWithClass(instance, 'notification')
+  //   const notificationEdited = findRenderedDOMComponentWithClass(instance, 'notify')
   //   expect(notificationEdited.getElementsByClassName('notify-title')[0].textContent).toBe(
   //     newTitle
   //   )
@@ -461,11 +461,10 @@ describe('NotifyPortal Component', () => {
   //   component.addNotification(notificationObj)
   //   let notification = findRenderedDOMComponentWithClass(
   //     instance,
-  //     'notifications-tl'
+  //     'notify-container-tl'
   //   ) as HTMLElement
   //   let width = notification.style.width
   //   expect(width).toBe('800px')
   //   done()
   // })
-
 })

--- a/test/components.spec.tsx
+++ b/test/components.spec.tsx
@@ -109,7 +109,7 @@ describe('NotifyItem', () => {
     const { root } = renderNotifications([getNote(defaultId)])
     const selector = CONSTANTS.testing.itemId(defaultId)
     let notification = root.getByTestId(selector)
-    let dismissButton = notification.querySelector('.notification-dismiss') as HTMLButtonElement
+    let dismissButton = notification.querySelector('.notify-dismiss') as HTMLButtonElement
     fireEvent.click(dismissButton)
     flushEffects()
     expect(() => root.getByTestId(selector)).toThrow()
@@ -121,7 +121,7 @@ describe('NotifyItem', () => {
     const { root } = renderNotifications([notificationObj])
     const container = root.getByTestId(CONSTANTS.testing.itemId(defaultId))
     expect(container).toBeTruthy()
-    expect(container.querySelector('.notification-title')).toBeFalsy()
+    expect(container.querySelector('.notify-title')).toBeFalsy()
   })
 
   it('should omit message elements for empty values', () => {
@@ -130,7 +130,7 @@ describe('NotifyItem', () => {
     const { root } = renderNotifications([notificationObj])
     const container = root.getByTestId(CONSTANTS.testing.itemId(defaultId))
     expect(container).toBeTruthy()
-    expect(container.querySelector('.notification-message')).toBeFalsy()
+    expect(container.querySelector('.notify-message')).toBeFalsy()
   })
 
   it('should not dismiss the notificaion on click if dismissible is false', () => {
@@ -168,7 +168,7 @@ describe('NotifyItem', () => {
     const { root } = renderNotifications([note])
     const container = root.getByTestId(CONSTANTS.testing.itemId(defaultId))
     expect(container).toBeTruthy()
-    expect(container.querySelector('.notification-action-button')).toBeTruthy()
+    expect(container.querySelector('.notify-action-button')).toBeTruthy()
   })
 
   it('should execute a callback function when notification button is clicked', () => {
@@ -184,7 +184,7 @@ describe('NotifyItem', () => {
     })
     const { root } = renderNotifications([note])
     const container = root.getByTestId(CONSTANTS.testing.itemId(defaultId))
-    const button = container.querySelector('.notification-action-button') as Element
+    const button = container.querySelector('.notify-action-button') as Element
     fireEvent.click(button)
     flushEffects()
     expect(clicked).toBe(true)
@@ -270,8 +270,8 @@ describe('NotifyPortal Component', () => {
   it('should not set a notification visibility class when the notification is initially added', () => {
     const { root } = renderNotifications([getNote(defaultId)])
     let notification = root.getByTestId(CONSTANTS.testing.itemId(defaultId))
-    expect(notification.className).not.toMatch(/notification-hidden/)
-    expect(notification.className).not.toMatch(/notification-visible/)
+    expect(notification.className).not.toMatch(/notify-hidden/)
+    expect(notification.className).not.toMatch(/notify-visible/)
   })
 
   xit('should set the notification class to visible after added', () => {
@@ -279,7 +279,7 @@ describe('NotifyPortal Component', () => {
     let notification = root.getByTestId(CONSTANTS.testing.itemId(defaultId))
     expect(notification.className).toMatch(/notification/)
     jest.runTimersToTime(400)
-    expect(notification.className).toMatch(/notification-visible/)
+    expect(notification.className).toMatch(/notify-visible/)
   })
 
   it('should render notifications in all positions with all levels', () => {
@@ -307,7 +307,7 @@ describe('NotifyPortal Component', () => {
     }
     containers.forEach(function(container) {
       for (let level of Object.keys(levels)) {
-        let notification = container.getElementsByClassName('notification-' + levels[level])
+        let notification = container.getElementsByClassName('notify-' + levels[level])
         expect(notification).not.toBeNull()
       }
     })
@@ -372,10 +372,10 @@ describe('NotifyPortal Component', () => {
   //   component.editNotification(notificationCreated, { title: newTitle, message: newContent })
   //   jest.runTimersToTime(1000)
   //   const notificationEdited = findRenderedDOMComponentWithClass(instance, 'notification')
-  //   expect(notificationEdited.getElementsByClassName('notification-title')[0].textContent).toBe(
+  //   expect(notificationEdited.getElementsByClassName('notify-title')[0].textContent).toBe(
   //     newTitle
   //   )
-  //   expect(notificationEdited.getElementsByClassName('notification-message')[0].textContent).toBe(
+  //   expect(notificationEdited.getElementsByClassName('notify-message')[0].textContent).toBe(
   //     newContent
   //   )
   //   done()
@@ -392,10 +392,10 @@ describe('NotifyPortal Component', () => {
   //   component.editNotification(notificationCreated.uid, { title: newTitle, message: newContent })
   //   jest.runTimersToTime(1000)
   //   const notificationEdited = findRenderedDOMComponentWithClass(instance, 'notification')
-  //   expect(notificationEdited.getElementsByClassName('notification-title')[0].textContent).toBe(
+  //   expect(notificationEdited.getElementsByClassName('notify-title')[0].textContent).toBe(
   //     newTitle
   //   )
-  //   expect(notificationEdited.getElementsByClassName('notification-message')[0].textContent).toBe(
+  //   expect(notificationEdited.getElementsByClassName('notify-message')[0].textContent).toBe(
   //     newContent
   //   )
   //   done()
@@ -427,7 +427,7 @@ describe('NotifyPortal Component', () => {
     })
     const { root } = renderNotifications([note])
     const notification = root.getByTestId(CONSTANTS.testing.itemId(defaultId))
-    let button = notification.querySelector('.notification-action-button') as HTMLButtonElement
+    let button = notification.querySelector('.notify-action-button') as HTMLButtonElement
     fireEvent.click(button)
     flushEffects()
     expect(() => root.getByTestId(CONSTANTS.testing.itemId(defaultId))).toThrow()


### PR DESCRIPTION
Shorten css classnames from `notification-*` to `notify-*`
 - this is consistent with the naming of the interfaces and components, and is shorter to type.
 - use classnames library to make conditional classnames much cleaner in item render.

BREAKING CHANGES: custom styling based on `notification-*` classes requires changes

Previously the prefix used for CSS class names was `notification`, and now it is `notify` Consider a few examples of before and after class names:

 - `notification-title` -> `notify-title`
 - `notification` -> `notify-item`
 - `notififcation-not-dismissable` -> `notify-not-dismissable`
