### PR TITLE
fix(container): issue where container did not go away with notification

### DIFF
--- a/src/components/container.tsx
+++ b/src/components/container.tsx
@@ -17,12 +17,25 @@ export interface NotifyContainerProps {
 }
 
 export class NotifyContainer extends React.Component<NotifyContainerProps> {
-  static propTypes = {}
+  static propTypes = {
+    position: PropTypes.string.isRequired,
+    notifications: PropTypes.array.isRequired,
+    getStyles: PropTypes.object,
+    onRemove: PropTypes.func,
+    noAnimation: PropTypes.bool,
+    allowHTML: PropTypes.bool,
+    children: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
+  }
   private _style: any
+  private _bottomPositions = [
+    CONSTANTS.positions.bl,
+    CONSTANTS.positions.br,
+    CONSTANTS.positions.bc
+  ]
 
   componentWillMount() {
     const { position, getStyles } = this.props
-    // Fix position if width is overrided
+    // Fix position if width is overridden
     this._style = getStyles.container(position)
     const isCenter = position === CONSTANTS.positions.tc || position === CONSTANTS.positions.bc
     if (getStyles.overrideWidth && isCenter) {
@@ -40,14 +53,11 @@ export class NotifyContainer extends React.Component<NotifyContainerProps> {
       notify,
       position
     } = this.props
-    if (
-      [CONSTANTS.positions.bl, CONSTANTS.positions.br, CONSTANTS.positions.bc].indexOf(
-        this.props.position
-      ) > -1
-    ) {
+    // Reverse the render order if the container position is along the bottom of the viewport
+    if (this._bottomPositions.indexOf(this.props.position) > -1) {
       this.props.notifications.reverse()
     }
-
+    const containerName = CONSTANTS.testing.containerTestId(position)
     const notifications = this.props.notifications.map(notification => {
       return (
         <NotifyItem
@@ -62,24 +72,10 @@ export class NotifyContainer extends React.Component<NotifyContainerProps> {
         />
       )
     })
-
-    const containerName = CONSTANTS.testing.containerTestId(position)
     return (
       <div data-testid={containerName} className={containerName} style={this._style}>
         {notifications}
       </div>
     )
-  }
-}
-
-if (process.env.NODE_ENV !== 'production') {
-  NotifyContainer.propTypes = {
-    position: PropTypes.string.isRequired,
-    notifications: PropTypes.array.isRequired,
-    getStyles: PropTypes.object,
-    onRemove: PropTypes.func,
-    noAnimation: PropTypes.bool,
-    allowHTML: PropTypes.bool,
-    children: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
   }
 }

--- a/src/components/item.tsx
+++ b/src/components/item.tsx
@@ -25,12 +25,19 @@ export interface NotifyItemState {
 }
 
 export class NotifyItem extends React.Component<NotifyItemProps, NotifyItemState> {
+  static propTypes = {
+    notification: PropTypes.object,
+    getStyles: PropTypes.object,
+    onRemove: PropTypes.func,
+    allowHTML: PropTypes.bool,
+    noAnimation: PropTypes.bool,
+    children: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
+  }
   static defaultProps = {
     noAnimation: false,
     onRemove: null,
     allowHTML: false
   }
-  static propTypes = {}
   private _styles: any = {}
   private _notificationTimer?: Timer
   private _height = 0
@@ -44,27 +51,124 @@ export class NotifyItem extends React.Component<NotifyItemProps, NotifyItemState
   }
 
   componentWillMount() {
-    let getStyles = this.props.getStyles
-    let level = this.props.notification.level
-    let dismissible = this.props.notification.dismissible
-
-    this._noAnimation = this.props.noAnimation
-
+    const { getStyles, notification, noAnimation } = this.props
+    const { byElement } = getStyles
+    const level = notification.level
+    const dismissible = notification.dismissible
+    this._noAnimation = noAnimation
     this._styles = {
-      notification: getStyles.byElement('notification')(level),
-      title: getStyles.byElement('title')(level),
-      dismiss: getStyles.byElement('dismiss')(level),
-      messageWrapper: getStyles.byElement('messageWrapper')(level),
-      actionWrapper: getStyles.byElement('actionWrapper')(level),
-      action: getStyles.byElement('action')(level)
+      notification: byElement('notification')(level),
+      title: byElement('title')(level),
+      dismiss: byElement('dismiss')(level),
+      messageWrapper: byElement('messageWrapper')(level),
+      actionWrapper: byElement('actionWrapper')(level),
+      action: byElement('action')(level)
     }
-
     if (!dismissible || dismissible === 'none' || dismissible === 'button') {
       this._styles.notification.cursor = 'default'
     }
   }
 
-  _getCssPropertyByPosition = () => {
+  componentWillUnmount() {
+    const element = findDOMNode(this) as HTMLElement
+    const transitionEvent = whichTransitionEvent()
+    element.removeEventListener(transitionEvent, this._onTransitionEnd)
+    this._isMounted = false
+  }
+  componentDidMount() {
+    const transitionEvent = whichTransitionEvent()
+    const notification = this.props.notification
+    const element = findDOMNode(this) as HTMLElement
+    this._height = element.offsetHeight
+    this._isMounted = true
+
+    // Watch for transition end
+    if (!this._noAnimation) {
+      if (transitionEvent) {
+        element.addEventListener(transitionEvent, this._onTransitionEnd)
+      } else {
+        this._noAnimation = true
+      }
+    }
+    if (notification.autoDismiss) {
+      this._notificationTimer = new Timer(() => {
+        this._hideNotification()
+      }, notification.autoDismiss * 1000)
+    }
+    this._showNotification()
+  }
+
+  //
+  // Lifecycle triggers
+  //
+  private _showNotification() {
+    setTimeout(() => {
+      if (this._isMounted) {
+        this.setState({
+          visible: true
+        })
+      }
+    }, 50)
+  }
+
+  private _hideNotification() {
+    if (this._notificationTimer) {
+      this._notificationTimer.clear()
+    }
+
+    if (this._isMounted) {
+      this.setState({
+        visible: false,
+        removed: true
+      })
+    }
+
+    if (this._noAnimation) {
+      this._removeNotification()
+    }
+  }
+
+  private _removeNotification() {
+    const { onRemove, notification, notify } = this.props
+    invariant(notify, "'notify' API must be passed to NotifyItem components explicitly")
+    notify.removeNotification(notification.uid)
+    if (onRemove) {
+      onRemove(notification ? notification.uid : -1)
+    }
+  }
+
+  //
+  // Calculated CSS styles
+  //
+  calculateNoteStyle(): React.CSSProperties {
+    const { visible, removed } = this.state
+    const { getStyles } = this.props
+    const notificationStyle = { ...this._styles.notification }
+    const cssPosition = this.calculateCSSPosition()
+    if (getStyles.overrideStyle) {
+      if (!visible && !removed) {
+        notificationStyle[cssPosition.property] = cssPosition.value
+      }
+
+      if (visible && !removed) {
+        notificationStyle.height = this._height
+        notificationStyle[cssPosition.property] = 0
+      }
+
+      if (removed) {
+        notificationStyle.overlay = 'hidden'
+        notificationStyle.height = 0
+        notificationStyle.marginTop = 0
+        notificationStyle.paddingTop = 0
+        notificationStyle.paddingBottom = 0
+      }
+      notificationStyle.opacity = visible
+        ? this._styles.notification.isVisible.opacity
+        : this._styles.notification.isHidden.opacity
+    }
+    return notificationStyle
+  }
+  calculateCSSPosition() {
     let position = this.props.notification.position
     let css = { property: 'left', value: 0 }
 
@@ -105,7 +209,24 @@ export class NotifyItem extends React.Component<NotifyItemProps, NotifyItemState
     return css
   }
 
-  _defaultAction = (event: any) => {
+  //
+  // Transition events
+  //
+  private _onTransitionEnd = () => {
+    if (this._removeCount > 0) {
+      return
+    }
+    if (this.state.removed) {
+      this._removeCount += 1
+      this._removeNotification()
+    }
+  }
+
+  //
+  // Input Event Handlers
+  //
+
+  private _defaultAction = (event: any) => {
     const { notification } = this.props
 
     event.preventDefault()
@@ -118,33 +239,7 @@ export class NotifyItem extends React.Component<NotifyItemProps, NotifyItemState
     }
   }
 
-  _hideNotification = () => {
-    if (this._notificationTimer) {
-      this._notificationTimer.clear()
-    }
-
-    if (this._isMounted) {
-      this.setState({
-        visible: false,
-        removed: true
-      })
-    }
-
-    if (this._noAnimation) {
-      this._removeNotification()
-    }
-  }
-
-  _removeNotification = () => {
-    const { onRemove, notification, notify } = this.props
-    invariant(notify, "'notify' API must be passed to NotifyItem components explicitly")
-    notify.destroyNotification(notification.uid)
-    if (onRemove) {
-      onRemove(notification ? notification.uid : -1)
-    }
-  }
-
-  _dismiss = () => {
+  private _dismiss = () => {
     const { notification } = this.props
     if (!notification || !notification.dismissible) {
       return
@@ -152,81 +247,35 @@ export class NotifyItem extends React.Component<NotifyItemProps, NotifyItemState
     this._hideNotification()
   }
 
-  _showNotification = () => {
-    setTimeout(() => {
-      if (this._isMounted) {
-        this.setState({
-          visible: true
-        })
-      }
-    }, 50)
-  }
-
-  _onTransitionEnd = () => {
-    if (this._removeCount > 0) return
-    if (this.state.removed) {
-      this._removeCount += 1
-      this._removeNotification()
-    }
-  }
-
-  componentDidMount = () => {
-    let transitionEvent = whichTransitionEvent()
-    let notification = this.props.notification
-    let element = findDOMNode(this) as HTMLElement
-    this._height = element.offsetHeight
-    this._isMounted = true
-
-    // Watch for transition end
-    if (!this._noAnimation) {
-      if (transitionEvent) {
-        element.addEventListener(transitionEvent, this._onTransitionEnd)
-      } else {
-        this._noAnimation = true
-      }
-    }
-
-    if (notification.autoDismiss) {
-      this._notificationTimer = new Timer(() => {
-        this._hideNotification()
-      }, notification.autoDismiss * 1000)
-    }
-
-    this._showNotification()
-  }
-
-  _handleMouseEnter = () => {
-    let notification = this.props.notification
+  private _handleMouseEnter = () => {
+    const { notification } = this.props
     if (notification.autoDismiss && this._notificationTimer) {
       this._notificationTimer.pause()
     }
   }
 
-  _handleMouseLeave = () => {
-    let notification = this.props.notification
+  private _handleMouseLeave = () => {
+    const { notification } = this.props
     if (notification.autoDismiss && this._notificationTimer) {
       this._notificationTimer.resume()
     }
   }
 
-  _handleNotificationClick = () => {
-    let dismissible = this.props.notification.dismissible
+  private _handleNotificationClick = () => {
+    const { notification } = this.props
+    const dismissible = notification.dismissible
     if (dismissible === 'both' || dismissible === 'click' || dismissible === true) {
       this._dismiss()
     }
   }
 
-  componentWillUnmount() {
-    let element = findDOMNode(this) as HTMLElement
-
-    let transitionEvent = whichTransitionEvent()
-    element.removeEventListener(transitionEvent, this._onTransitionEnd)
-    this._isMounted = false
-  }
-
   render() {
     const { visible, removed } = this.state
-    const { notification, getStyles: styles } = this.props
+    const { notification } = this.props
+    const canDismiss =
+      notification.dismissible === 'both' ||
+      notification.dismissible === 'button' ||
+      notification.dismissible === true
     const className = classNames(
       'notify',
       'notify-item',
@@ -238,34 +287,11 @@ export class NotifyItem extends React.Component<NotifyItemProps, NotifyItemState
         'notify-not-dismissable': notification.dismissible === 'none'
       }
     )
-    let notificationStyle = { ...this._styles.notification }
-    let cssByPos = this._getCssPropertyByPosition()
+    const notificationStyle = this.calculateNoteStyle()
     let dismiss = null
     let actionButton = null
     let title = null
     let message = null
-
-    if (styles.overrideStyle) {
-      if (!visible && !removed) {
-        notificationStyle[cssByPos.property] = cssByPos.value
-      }
-
-      if (visible && !removed) {
-        notificationStyle.height = this._height
-        notificationStyle[cssByPos.property] = 0
-      }
-
-      if (removed) {
-        notificationStyle.overlay = 'hidden'
-        notificationStyle.height = 0
-        notificationStyle.marginTop = 0
-        notificationStyle.paddingTop = 0
-        notificationStyle.paddingBottom = 0
-      }
-      notificationStyle.opacity = visible
-        ? this._styles.notification.isVisible.opacity
-        : this._styles.notification.isHidden.opacity
-    }
 
     if (notification.title) {
       title = (
@@ -292,11 +318,7 @@ export class NotifyItem extends React.Component<NotifyItemProps, NotifyItemState
         )
       }
     }
-    if (
-      notification.dismissible === 'both' ||
-      notification.dismissible === 'button' ||
-      notification.dismissible === true
-    ) {
+    if (canDismiss) {
       dismiss = (
         <span className="notify-dismiss" onClick={this._dismiss} style={this._styles.dismiss}>
           &times;
@@ -360,15 +382,4 @@ function whichTransitionEvent(): string {
 
 function _allowHTML(input: any) {
   return { __html: input }
-}
-
-if (process.env.NODE_ENV !== 'production') {
-  NotifyItem.propTypes = {
-    notification: PropTypes.object,
-    getStyles: PropTypes.object,
-    onRemove: PropTypes.func,
-    allowHTML: PropTypes.bool,
-    noAnimation: PropTypes.bool,
-    children: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
-  }
 }

--- a/src/components/portal.tsx
+++ b/src/components/portal.tsx
@@ -1,18 +1,9 @@
 import React, { useEffect, useState, RefObject, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { STYLES } from '../styles'
-import {
-  NotifyOpts,
-  NotifyStyle,
-  NotifyState,
-  NotifyDispatch,
-  NotifyContainersStyle,
-  NotifyPosition
-} from '../types'
+import { NotifyOpts, NotifyStyle, NotifyContainersStyle, NotifyPosition } from '../types'
 import { CONSTANTS } from '../constants'
-import { NotifyItem } from './item'
 import { NotifyContainer } from './container'
-import { NotifyReducer } from '../model/reducer'
 import { useNotify } from '../hooks/useNotify'
 
 export interface NotifyPortalProps {
@@ -39,7 +30,6 @@ export function NotifyPortal(props: NotifyPortalProps) {
   const [isMounted, setIsMounted] = useState(false)
   const [overrideStyle, setOverrideStyle] = useState<NotifyStyle | null>(null)
   const [overrideWidth, setOverrideWidth] = useState<NotifyStyle | null>(null)
-  const refDictionary = useRef<{ [key: string]: RefObject<NotifyContainer> }>({})
   useEffect(function onInit() {
     if (style !== false) {
       setOverrideStyle(style)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,8 +39,7 @@ export const CONSTANTS: IConstants = {
     position: 'tr',
     autoDismiss: 5,
     dismissible: 'both',
-    action: undefined,
-    hidden: false
+    action: undefined
   },
 
   testing: {

--- a/src/model/actions.ts
+++ b/src/model/actions.ts
@@ -32,39 +32,6 @@ export function NotifyShow(payload: Partial<NotifyOpts>, level?: NotifyLevel): I
 }
 
 /** String literal type constant for hide notification action "type" member */
-export const NotifyHideType = '@hideNotification'
-/** Redux action object shape for hiding a notification */
-export interface INotifyHide {
-  readonly payload: number
-  readonly type: '@hideNotification'
-}
-/**
- * Generate redux-compatible Action object that hides any notification with
- * the given id when dispatched
- */
-export function NotifyHide(uid: number): INotifyHide {
-  return {
-    type: NotifyHideType,
-    payload: uid
-  }
-}
-
-/** String literal type constant for hide all notifications action "type" member */
-export const NotifyHideAllType = '@hideAllNotifications'
-/** Redux action object shape for hiding all notifications */
-export interface INotifyHideAll {
-  readonly type: '@hideAllNotifications'
-}
-/**
- * Generate a redux-compatible Action object that hides all notifications when dispatched
- */
-export function NotifyHideAll(): INotifyHideAll {
-  return {
-    type: NotifyHideAllType
-  }
-}
-
-/** String literal type constant for hide notification action "type" member */
 export const NotifyRemoveType = '@removeNotification'
 /** Redux action object shape for hiding a notification */
 export interface INotifyRemove {
@@ -147,10 +114,4 @@ export function NotifyInfo(payload: Partial<NotifyOpts>) {
  * Tagged union types (note the convenience functions that set levels are not
  * here because they share an action type with IShowNotification)
  */
-export type NotifyActionTypes =
-  | INotifyShow
-  | INotifyHide
-  | INotifyHideAll
-  | INotifyRemove
-  | INotifyEdit
-  | INotifyClear
+export type NotifyActionTypes = INotifyShow | INotifyRemove | INotifyEdit | INotifyClear

--- a/src/model/api.ts
+++ b/src/model/api.ts
@@ -1,5 +1,5 @@
 import { NotifyOpts, NotifyState, NotifyDispatch } from '../types'
-import { NotifyHide, NotifyShow, NotifyEdit, NotifyClear, NotifyRemove } from './actions'
+import { NotifyShow, NotifyEdit, NotifyClear, NotifyRemove } from './actions'
 import { invariant } from '../helpers'
 
 export class NotifyAPI {
@@ -21,14 +21,6 @@ export class NotifyAPI {
   }
 
   removeNotification(uid: number): boolean {
-    const notification = this.findNotification(uid)
-    if (notification) {
-      this.dispatch(NotifyHide(uid))
-      return true
-    }
-    return false
-  }
-  destroyNotification(uid: number): boolean {
     const notification = this.findNotification(uid)
     if (notification) {
       this.dispatch(NotifyRemove(uid))

--- a/src/model/reducer.ts
+++ b/src/model/reducer.ts
@@ -1,11 +1,9 @@
 import {
   NotifyShowType,
-  NotifyHideType,
   NotifyClearType,
   NotifyActionTypes,
   NotifyEditType,
-  NotifyRemoveType,
-  NotifyHideAllType
+  NotifyRemoveType
 } from './actions'
 import { NotifyOpts, NotifyState } from '../types'
 import { exhaustiveCheck, invariant } from '../helpers'
@@ -58,20 +56,6 @@ export function NotifyReducer(
         }
         return { notifications: [...state.notifications, { ...draft }] }
       }
-      case NotifyHideType: {
-        const { payload } = action
-        return {
-          notifications: state.notifications.map(n => {
-            if (n.uid === payload) {
-              return {
-                ...n,
-                hidden: true
-              }
-            }
-            return n
-          })
-        }
-      }
       case NotifyEditType: {
         const { payload } = action
         invariant(payload.uid, `uid is required to edit a notification, but got: ${payload.uid}`)
@@ -94,16 +78,6 @@ export function NotifyReducer(
         const { payload } = action
         return {
           notifications: state.notifications.filter(n => n.uid !== payload)
-        }
-      }
-      case NotifyHideAllType: {
-        return {
-          notifications: state.notifications.map(n => {
-            return {
-              ...n,
-              hidden: true
-            }
-          })
         }
       }
       /* istanbul ignore next */

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,6 @@ export interface NotifyOpts {
   children?: React.ReactNode
   onAdd?: NotifyCallback
   onRemove?: NotifyCallback
-  hidden?: boolean
   uid: number
   data?: any
 }

--- a/test/reducer.spec.ts
+++ b/test/reducer.spec.ts
@@ -1,6 +1,5 @@
 import {
   NotifyReducer,
-  NotifyHide,
   NotifySuccess,
   NotifyClear,
   getInitialNotifyState,
@@ -67,15 +66,6 @@ describe('reducer', () => {
       expect(() => NotifyReducer(state, action)).toThrow(/"autoDismiss" must be a number./)
     })
   })
-  describe('NotifyHide', () => {
-    it('marks notifications as hidden but does not remove them', () => {
-      const state = singleNotification()
-      const newState = NotifyReducer(state, NotifyHide(defaultId))
-      const notification = newState.notifications[0]
-      expect(notification).toBeTruthy()
-      expect(notification.hidden).toBe(true)
-    })
-  })
   it('stores the notification to state', () => {
     const action = NotifySuccess({})
     const state = NotifyReducer(getInitialNotifyState(), action)
@@ -87,16 +77,6 @@ describe('reducer', () => {
     const uid = 1
     const state = NotifyReducer(getInitialNotifyState(), NotifySuccess({ uid }))
     expect(state.notifications.length).toBe(1)
-  })
-
-  describe('NotifyHide', () => {
-    it('marks notifications with hidden=true', () => {
-      const uid = 1
-      const state = NotifyReducer(getInitialNotifyState(), NotifySuccess({ uid }))
-      expect(state.notifications.length).toBe(1)
-      const newState = NotifyReducer(state, NotifyHide(uid))
-      expect(newState.notifications[0].hidden).toBe(true)
-    })
   })
 
   describe('NotifyEdit', () => {


### PR DESCRIPTION
 - the notifications were visibly hidden, so the container still exists to render them. Bite the bullet and delete them ungracefully. Let's see what it does to the animations.
 - clean up some misc implementation junk.

BREAKING CHANGE: NotifyHide is removed